### PR TITLE
Removed “a” tag from plugin summary.

### DIFF
--- a/MarshallersGrailsPlugin.groovy
+++ b/MarshallersGrailsPlugin.groovy
@@ -57,7 +57,7 @@ class MarshallersGrailsPlugin {
     def description = '''\\
 Easy registration and usage of custom XML and JSON marshallers supporting hierarchical configurations.
 
-Further documentation can be found <a href="http://github.com/pedjak/grails-marshallers">here</a>.
+Further documentation can be found on the GitHub repo.
 '''
 
     // URL to the plugin's documentation


### PR DESCRIPTION
HTML tags seem to not be working in the plugin summary tab, so I removed the link to the GitHub repo.
I think it's not necessary because you can get to the same place by clicking the "Documentation" button.
