### PR TITLE
in grails 2.3 a typo was fixed which subsequently breaks this plugin

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,5 +1,5 @@
 #Grails Metadata file
-#Tue May 28 09:46:32 CEST 2013
-app.grails.version=2.2.3
+#Mon Dec 30 00:36:15 CST 2013
+app.grails.version=2.3.3
 app.name=marshallers
-
+app.servlet.version=2.5

--- a/src/groovy/org/grails/plugins/marshallers/ConfigurationBuilder.groovy
+++ b/src/groovy/org/grails/plugins/marshallers/ConfigurationBuilder.groovy
@@ -25,7 +25,7 @@ import groovy.lang.Closure;
 
 import org.codehaus.groovy.grails.web.converters.Converter;
 
-import org.codehaus.groovy.grails.web.converters.marshaller.ClosureOjectMarshaller;
+import org.codehaus.groovy.grails.web.converters.marshaller.ClosureObjectMarshaller;
 
 import groovy.lang.Closure;
 import org.codehaus.groovy.grails.commons.GrailsClassUtils as GCU
@@ -117,7 +117,7 @@ class ConfigurationBuilder {
     }
 }
 
-class NameAwareClosureObjectMarshaller<T extends Converter> extends ClosureOjectMarshaller<T> implements NameAwareMarshaller {
+class NameAwareClosureObjectMarshaller<T extends Converter> extends ClosureObjectMarshaller<T> implements NameAwareMarshaller {
     
     def elementName
     


### PR DESCRIPTION
Fixes the issue reported in #8.  This plugin does not work at all in 2.3+ because Grails changed a class name and the reference is no longer valid.
